### PR TITLE
Added couple of attributes to the events schema

### DIFF
--- a/schemas/events.json
+++ b/schemas/events.json
@@ -14,7 +14,13 @@
         "fn": { "type": "string" },
         "params": { "$ref": "#/definitions/params" },
         "body": { "type": "object" },
-        "responses": { "type": "object" }
+        "responses": { "type": "object" },
+        "authn": { "type": "boolean" },
+        "on_validation_error": {
+          "type" : "string",
+          "$comment": "This should later only allow valid identifiers denoting a function, currently fn property is also a string",
+          "description": "Specifies a function which would be run if a validation error happens for the request"
+        }
       }
     }
   },


### PR DESCRIPTION
Added 2 top level attributes to an event specification: authn, on_validation_error. Authn can be specified optionally to enable authentication checks (this is currently just a boolean attribute, however we need to discuss if there would be additional properties in case of dynamic jwt token based authentication or other flavours). On_validation_error allows an arbitrary string just like what fn does today. Both of these can be improved in the future to only allow valid function identifiers either via a regex or via some index file (unclear how that would work though)